### PR TITLE
Make errors on read streams safe, by delaying read until someone is attached

### DIFF
--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -164,6 +164,22 @@ testBoth(
 )
 
 testBoth(
+	'should fail cleanly trying to read a missing file on a raspberrypi'
+	(input) ->
+		Promise.using imagefs.read(input), (stream) ->
+			utils.extract(stream)
+		.then (contents) ->
+			throw new Error('Should not successfully return contents for a missing file!')
+		.catch (e) ->
+			utils.expect(e.code, 'NOENT')
+	{
+		image: RASPBERRYPI
+		partition: 5
+		path: '/non-existent-file.txt'
+	}
+)
+
+testBoth(
 	'should copy files between different partitions in a raspberrypi'
 	(input, output) ->
 		imagefs.copy(input, output)


### PR DESCRIPTION
This doesn't start the real read until somebody adds a listener (e.g. `on('data')'` or `.pipe`) to the returned stream. Without this change, the test here fails, inconsistently (typically crashing the process with a NOENT before the stream is returned).

There are other ways to try to handle errors (like doing an open upfront read, or trying to buffer errors alone and detect when to release them), but they're trickier, and all introduce race conditions of some kind (e.g. any kind of non-open error, a change in the image due to parallel writers between the open and the read itself). This approach is (as far as I know!) totally reliable - as long as you start watching for errors within the synchronous event that you start reading data, you'll always be able to handle every error.

Change-Type: patch